### PR TITLE
Swap homepage to version

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -16,6 +16,6 @@ if (cli.input.length === 0) {
 
 npmUserPackages(cli.input[0]).then(data => {
 	for (const x of data) {
-		console.log(`${x.name} ${chalk.dim(x.homepage)}`);
+		console.log(`${x.name} ${chalk.dim(x.version)}`);
 	}
 });


### PR DESCRIPTION
Seems like npm does't deliver homepage info any longer,
swaped to show current version of the package.

Data we get from the endpoint 

```
  name: 'pkg-downloads',
  description: 'Check total downloads of a npm package',
  maintainers: [ 'alonalon' ],
  'dist-tags': { latest: '2.2.0' },
  access: 'public',
  permissions: 'write',
  version: '2.2.0' },
{ lastPublish: { maintainer: 'alonalon', time: '2016-01-18T19:37:15.790Z' },
```

Screenshot with versions instead: 

![screen shot 2017-07-06 at 01 15 23](https://user-images.githubusercontent.com/3322693/27888883-e91dfc64-61e8-11e7-96f0-b7eabccb93f3.png)
